### PR TITLE
Fixed output_dir parameter name

### DIFF
--- a/experiments/prepare_datasets.py
+++ b/experiments/prepare_datasets.py
@@ -126,8 +126,8 @@ if __name__ == "__main__":
 
     setup_logging()
 
-    if os.path.exists(args.output_path):
-        logging.error(f"The output path {args.output_path} already exists.")
+    if os.path.exists(args.output_dir):
+        logging.error(f"The output path {args.output_dir} already exists.")
         exit()
         
     process_masks(args.input_path, args.output_dir, args.corresponding_files_dir, args.val_pattern, args.test_pattern, args.format)


### PR DESCRIPTION
Changed  `output_path` to `output_dir` to be the same name as it was defined in the `argparse`. This fix name not found error.
